### PR TITLE
Added methods from MQTT API and examples

### DIFF
--- a/examples/0000-arduino_send_telemetry/0000-arduino_send_telemetry.ino
+++ b/examples/0000-arduino_send_telemetry/0000-arduino_send_telemetry.ino
@@ -17,7 +17,7 @@
 // See https://thingsboard.io/docs/getting-started-guides/helloworld/ 
 // to understand how to obtain an access token
 #define TOKEN               "YOUR_ACCESS_TOKEN"
-#define THINGSBOARD_SERVER  "demo.thingsboard.io"
+#define THINGSBOARD_SERVER  "thingsboard.cloud"
 
 // Baud rate for serial debug
 #define SERIAL_DEBUG_BAUD   9600

--- a/examples/0001-arduino_send_batch/0001-arduino_send_batch.ino
+++ b/examples/0001-arduino_send_batch/0001-arduino_send_batch.ino
@@ -17,7 +17,7 @@
 // See https://thingsboard.io/docs/getting-started-guides/helloworld/ 
 // to understand how to obtain an access token
 #define TOKEN               "YOUR_ACCESS_TOKEN"
-#define THINGSBOARD_SERVER  "demo.thingsboard.io"
+#define THINGSBOARD_SERVER  "thingsboard.cloud"
 
 // Baud rate for serial debug
 #define SERIAL_DEBUG_BAUD   9600

--- a/examples/0002-arduino_rpc/0002-arduino_rpc.ino
+++ b/examples/0002-arduino_rpc/0002-arduino_rpc.ino
@@ -17,7 +17,7 @@
 // See https://thingsboard.io/docs/getting-started-guides/helloworld/
 // to understand how to obtain an access token
 #define TOKEN               "YOUR_ACCESS_TOKEN"
-#define THINGSBOARD_SERVER  "demo.thingsboard.io"
+#define THINGSBOARD_SERVER  "thingsboard.cloud"
 
 // Serial driver for ESP
 SoftwareSerial soft(2, 3); // RX, TX

--- a/examples/0003-esp8266_send_data/0003-esp8266_send_data.ino
+++ b/examples/0003-esp8266_send_data/0003-esp8266_send_data.ino
@@ -9,7 +9,7 @@
 // See https://thingsboard.io/docs/getting-started-guides/helloworld/
 // to understand how to obtain an access token
 #define TOKEN               "YOUR_ACCESS_TOKEN"
-#define THINGSBOARD_SERVER  "demo.thingsboard.io"
+#define THINGSBOARD_SERVER  "thingsboard.cloud"
 
 // Baud rate for debug serial
 #define SERIAL_DEBUG_BAUD   115200

--- a/examples/0004-arduino-sim900_send_telemetry/0004-arduino-sim900_send_telemetry.ino
+++ b/examples/0004-arduino-sim900_send_telemetry/0004-arduino-sim900_send_telemetry.ino
@@ -29,7 +29,7 @@ const char pass[] = "";
 // See https://thingsboard.io/docs/getting-started-guides/helloworld/
 // to understand how to obtain an access token
 #define TOKEN               "YOUR_ACCESS_TOKEN"
-#define THINGSBOARD_SERVER  "demo.thingsboard.io"
+#define THINGSBOARD_SERVER  "thingsboard.cloud"
 
 // Baud rate for debug serial
 #define SERIAL_DEBUG_BAUD   115200

--- a/examples/0005-arduino-sim900_send_telemetry_http/0005-arduino-sim900_send_telemetry_http.ino
+++ b/examples/0005-arduino-sim900_send_telemetry_http/0005-arduino-sim900_send_telemetry_http.ino
@@ -29,7 +29,7 @@ const char pass[] = "";
 // See https://thingsboard.io/docs/getting-started-guides/helloworld/
 // to understand how to obtain an access token
 #define TOKEN               "YOUR_ACCESS_TOKEN"
-#define THINGSBOARD_SERVER  "demo.thingsboard.io"
+#define THINGSBOARD_SERVER  "thingsboard.cloud"
 #define THINGSBOARD_PORT    80
 
 // Baud rate for debug serial

--- a/examples/0006-esp8266_process_shared_attribute_update/0006-esp8266_process_shared_attribute_update.ino
+++ b/examples/0006-esp8266_process_shared_attribute_update/0006-esp8266_process_shared_attribute_update.ino
@@ -1,0 +1,110 @@
+#include "ThingsBoard.h"
+
+#include <ESP8266WiFi.h>
+
+
+#define WIFI_AP             "YOUR_WIFI_SSID"
+#define WIFI_PASSWORD       "YOUR_WIFI_PASSWORD"
+
+// See https://thingsboard.io/docs/getting-started-guides/helloworld/
+// to understand how to obtain an access token
+#define TOKEN               "YOUR_DEVICE_ACCESS_TOKEN"
+#define THINGSBOARD_SERVER  "thingsboard.cloud"
+
+
+// Baud rate for debug serial
+#define SERIAL_DEBUG_BAUD   115200
+
+// Initialize ThingsBoard client
+WiFiClient espClient;
+// Initialize ThingsBoard instance
+ThingsBoard tb(espClient);
+// the Wifi radio's status
+int status = WL_IDLE_STATUS;
+bool subscribed = false;
+
+void setup() {
+  // initialize serial for debugging
+  Serial.begin(SERIAL_DEBUG_BAUD);
+  WiFi.begin(WIFI_AP, WIFI_PASSWORD);
+  InitWiFi();
+}
+
+void processSharedAttributeUpdate(const Shared_Attribute_Data &data) {
+  for (JsonObject::iterator it = data.begin(); it != data.end(); ++it) {
+    Serial.println(it->key().c_str());
+    Serial.println(it->value().as<char*>()); // We have to parse data by it's type in the current example we will show here only char data
+  }
+
+  int jsonSize = measureJson(data) + 1;
+  char buffer[jsonSize];
+  serializeJson(data, buffer, jsonSize);
+  Serial.println(buffer);
+}
+
+Shared_Attribute_Callback callbacks[1] = {
+  processSharedAttributeUpdate
+};
+
+
+void loop() {
+  delay(1000);
+
+  if (WiFi.status() != WL_CONNECTED) {
+    reconnect();
+  }
+
+  if (!tb.connected()) {
+    // Connect to the ThingsBoard
+    Serial.print("Connecting to: ");
+    Serial.print(THINGSBOARD_SERVER);
+    Serial.print(" with token ");
+    Serial.println(TOKEN);
+    if (!tb.connect(THINGSBOARD_SERVER, TOKEN)) {
+      Serial.println("Failed to connect");
+      return;
+    }
+
+  }
+
+  if (!subscribed) {
+    Serial.println("Subscribing for shared attribute updates...");
+
+    if (!tb.Shared_Attributes_Subscribe(callbacks, 1)) {
+      Serial.println("Failed to subscribe for shared attribute updates");
+      return;
+    }
+
+    Serial.println("Subscribe done");
+    subscribed = true;
+  }
+
+  tb.loop();
+}
+
+void InitWiFi()
+{
+  Serial.println("Connecting to AP ...");
+  // attempt to connect to WiFi network
+
+  WiFi.begin(WIFI_AP, WIFI_PASSWORD);
+  while (WiFi.status() != WL_CONNECTED) {
+
+    delay(500);
+    Serial.print(".");
+  }
+  Serial.println("Connected to AP");
+}
+
+void reconnect() {
+  // Loop until we're reconnected
+  status = WiFi.status();
+  if ( status != WL_CONNECTED) {
+    WiFi.begin(WIFI_AP, WIFI_PASSWORD);
+    while (WiFi.status() != WL_CONNECTED) {
+      delay(500);
+      Serial.print(".");
+    }
+    Serial.println("Connected to AP");
+  }
+}

--- a/examples/0007-esp8266_claim_device/0007-esp8266_claim_device.ino
+++ b/examples/0007-esp8266_claim_device/0007-esp8266_claim_device.ino
@@ -47,7 +47,7 @@ void loop() {
     Serial.print(THINGSBOARD_SERVER);
     Serial.print(" with token ");
     Serial.println(TOKEN);
-    if (!tb.connect(THINGSBOARD_SERVER, TOKEN, 1884)) {
+    if (!tb.connect(THINGSBOARD_SERVER, TOKEN, 1883)) {
       Serial.println("Failed to connect");
       return;
     }

--- a/examples/0007-esp8266_claim_device/0007-esp8266_claim_device.ino
+++ b/examples/0007-esp8266_claim_device/0007-esp8266_claim_device.ino
@@ -3,13 +3,13 @@
 #include <ESP8266WiFi.h>
 
 
-#define WIFI_AP             "ThingsBoardTN"
-#define WIFI_PASSWORD       "4Friends123!"
+#define WIFI_AP             "YOUR_WIFI_AP"
+#define WIFI_PASSWORD       "YOUR_WIFI_PASSWORD"
 
 // See https://thingsboard.io/docs/getting-started-guides/helloworld/
 // to understand how to obtain an access token
-#define TOKEN               "qweqwe"
-#define THINGSBOARD_SERVER  "192.168.0.2"
+#define TOKEN               "YOUR_ACCESS_TOKEN"
+#define THINGSBOARD_SERVER  "thingsboard.cloud"
 
 
 // Baud rate for debug serial
@@ -23,7 +23,7 @@ ThingsBoard tb(espClient);
 int status = WL_IDLE_STATUS;
 bool claimingRequestSent = false;
 
-const char* claimingRequestSecretKey = "VERY_SECRET_KEY";
+const char* claimingRequestSecretKey = "YOUR_VERY_SECRET_KEY";
 unsigned int claimingRequestDurationMs = 180000;
 
 void setup() {

--- a/examples/0007-esp8266_claim_device/0007-esp8266_claim_device.ino
+++ b/examples/0007-esp8266_claim_device/0007-esp8266_claim_device.ino
@@ -1,0 +1,91 @@
+#include "ThingsBoard.h"
+
+#include <ESP8266WiFi.h>
+
+
+#define WIFI_AP             "ThingsBoardTN"
+#define WIFI_PASSWORD       "4Friends123!"
+
+// See https://thingsboard.io/docs/getting-started-guides/helloworld/
+// to understand how to obtain an access token
+#define TOKEN               "qweqwe"
+#define THINGSBOARD_SERVER  "192.168.0.2"
+
+
+// Baud rate for debug serial
+#define SERIAL_DEBUG_BAUD   115200
+
+// Initialize ThingsBoard client
+WiFiClient espClient;
+// Initialize ThingsBoard instance
+ThingsBoard tb(espClient);
+// the Wifi radio's status
+int status = WL_IDLE_STATUS;
+bool claimingRequestSent = false;
+
+const char* claimingRequestSecretKey = "VERY_SECRET_KEY";
+unsigned int claimingRequestDurationMs = 180000;
+
+void setup() {
+  // initialize serial for debugging
+  Serial.begin(SERIAL_DEBUG_BAUD);
+  WiFi.begin(WIFI_AP, WIFI_PASSWORD);
+  InitWiFi();
+}
+
+
+void loop() {
+  delay(1000);
+
+  if (WiFi.status() != WL_CONNECTED) {
+    reconnect();
+  }
+
+  if (!tb.connected()) {
+    // Connect to the ThingsBoard
+    Serial.print("Connecting to: ");
+    Serial.print(THINGSBOARD_SERVER);
+    Serial.print(" with token ");
+    Serial.println(TOKEN);
+    if (!tb.connect(THINGSBOARD_SERVER, TOKEN, 1884)) {
+      Serial.println("Failed to connect");
+      return;
+    }
+
+  }
+
+  if (!claimingRequestSent) {
+    if (tb.sendClaimingRequest(claimingRequestSecretKey, claimingRequestDurationMs)) {
+      claimingRequestSent = true;
+    }
+  }
+
+  tb.loop();
+}
+
+void InitWiFi()
+{
+  Serial.println("Connecting to AP ...");
+  // attempt to connect to WiFi network
+
+  WiFi.begin(WIFI_AP, WIFI_PASSWORD);
+  while (WiFi.status() != WL_CONNECTED) {
+
+    delay(500);
+    Serial.print(".");
+  }
+  Serial.println("Connected to AP");
+}
+
+void reconnect() {
+  // Loop until we're reconnected
+  status = WiFi.status();
+  if ( status != WL_CONNECTED) {
+    WiFi.begin(WIFI_AP, WIFI_PASSWORD);
+    while (WiFi.status() != WL_CONNECTED) {
+      delay(500);
+      Serial.print(".");
+    }
+    Serial.println("Connected to AP");
+  }
+}

--- a/examples/0008-esp8266_provision_device/0008-esp8266_provision_device.ino
+++ b/examples/0008-esp8266_provision_device/0008-esp8266_provision_device.ino
@@ -1,0 +1,162 @@
+#include "ThingsBoard.h"
+
+#include <ESP8266WiFi.h>
+
+
+#define WIFI_AP             "YOUR_WIFI_SSID"
+#define WIFI_PASSWORD       "YOUR_WIFI_PASSWORD"
+
+#define THINGSBOARD_SERVER  "thingsboard.cloud"
+#define THINGSBOARD_PORT    1883
+
+const char* provisionDeviceKey = "YOUR_PROVISION_DEVICE_KEY";
+const char* provisionDeviceSecret = "YOUR_PROVISION_DEVICE_SECRET";
+const char* deviceName = "YOUR_DEVICE_NAME";
+
+// Baud rate for debug serial
+#define SERIAL_DEBUG_BAUD   115200
+
+// Initialize ThingsBoard client
+WiFiClient espClient;
+// Initialize ThingsBoard client provision instance
+ThingsBoard tb_provision(espClient);
+
+// Initialize Thingsboard instance
+ThingsBoard tb(espClient);
+
+// the Wifi radio's status
+int status = WL_IDLE_STATUS;
+
+unsigned long previous_processing_time;
+
+// Statuses for provisioning
+bool provisionRequestSent = false;
+volatile bool provisionResponseProcessed = false;
+
+// Struct for client connecting after provisioning
+struct Credentials {
+  String client_id;
+  String username;
+  String password;
+};
+
+Credentials credentials;
+
+void setup() {
+  // initialize serial for debugging
+  Serial.begin(SERIAL_DEBUG_BAUD);
+  WiFi.begin(WIFI_AP, WIFI_PASSWORD);
+  InitWiFi();
+  previous_processing_time = millis();
+}
+
+void processProvisionResponse(const Provision_Data &data) {
+  Serial.println("Received device provision response");
+  int jsonSize = measureJson(data) + 1;
+  char buffer[jsonSize];
+  serializeJson(data, buffer, jsonSize);
+  Serial.println(buffer);
+  if (strncmp(data["status"], "SUCCESS", strlen("SUCCESS")) != 0) {
+    Serial.print("Provision response contains the error: ");
+    Serial.println(data["errorMsg"].as<String>());
+    provisionResponseProcessed = true;
+    return;
+  }
+  if (strncmp(data["credentialsType"], "ACCESS_TOKEN", strlen("ACCESS_TOKEN")) == 0) {
+    credentials.client_id = "";
+    credentials.username = data["credentialsValue"].as<String>();
+    credentials.password = "";
+  }
+  if (strncmp(data["credentialsType"], "MQTT_BASIC", strlen("MQTT_BASIC")) == 0) {
+    JsonObject credentials_value = data["credentialsValue"].as<JsonObject>();
+    credentials.client_id = credentials_value["clientId"].as<String>();
+    credentials.username = credentials_value["userName"].as<String>();
+    credentials.password = credentials_value["password"].as<String>();
+  }
+  if (tb_provision.connected()) {
+    tb_provision.disconnect();
+  }
+  provisionResponseProcessed = true;
+}
+
+const Provision_Callback provisionCallback = processProvisionResponse;
+
+void loop() {
+  if (millis() - previous_processing_time >= 1000) {
+    previous_processing_time = millis();
+    if (WiFi.status() != WL_CONNECTED) {
+      reconnect();
+    }
+
+    if (!provisionRequestSent) {
+      if (!tb_provision.connected()) {
+        // Connect to the ThingsBoard
+        Serial.print("Connecting to: ");
+        Serial.print(THINGSBOARD_SERVER);
+        if (!tb_provision.connect(THINGSBOARD_SERVER, "provision", THINGSBOARD_PORT)) {
+          Serial.println("Failed to connect");
+          return;
+        }
+        if (tb_provision.Provision_Subscribe(provisionCallback)) {
+          if (tb_provision.sendProvisionRequest(deviceName, provisionDeviceKey, provisionDeviceSecret)) {
+            provisionRequestSent = true;
+            Serial.println("Provision request was sent!");
+          }
+        }
+      }
+
+    } else if (provisionResponseProcessed) {
+      if (!tb.connected()) {
+        // Connect to the ThingsBoard
+        Serial.print("Connecting to: ");
+        Serial.println(THINGSBOARD_SERVER);
+        if (!tb.connect(THINGSBOARD_SERVER, credentials.username.c_str(), THINGSBOARD_PORT, credentials.client_id.c_str(), credentials.password.c_str())) {
+          Serial.println("Failed to connect");
+          Serial.println(credentials.client_id.c_str());
+          Serial.println(credentials.username.c_str());
+          Serial.println(credentials.password.c_str());
+          return;
+        } else {
+          Serial.println("Connected!");
+        }
+      } else {
+        Serial.println("Sending telemetry...");
+        tb.sendTelemetryInt("temperature", 22);
+        tb.sendTelemetryFloat("humidity", 42.5);
+      }
+    }
+
+    if (!provisionResponseProcessed) {
+      tb_provision.loop();
+    } else {
+      tb.loop();
+    }
+  }
+}
+
+void InitWiFi()
+{
+  Serial.println("Connecting to AP ...");
+  // attempt to connect to WiFi network
+
+  WiFi.begin(WIFI_AP, WIFI_PASSWORD);
+  while (WiFi.status() != WL_CONNECTED) {
+
+    delay(500);
+    Serial.print(".");
+  }
+  Serial.println("Connected to AP");
+}
+
+void reconnect() {
+  // Loop until we're reconnected
+  status = WiFi.status();
+  if ( status != WL_CONNECTED) {
+    WiFi.begin(WIFI_AP, WIFI_PASSWORD);
+    while (WiFi.status() != WL_CONNECTED) {
+      delay(500);
+      Serial.print(".");
+    }
+    Serial.println("Connected to AP");
+  }
+}

--- a/src/ThingsBoard.h
+++ b/src/ThingsBoard.h
@@ -182,6 +182,27 @@ public:
   }
 
   //----------------------------------------------------------------------------
+  // Claiming API
+
+  bool sendClaimingRequest(const char *secretKey, unsigned int durationMs) {
+      StaticJsonDocument<JSON_OBJECT_SIZE(1)> respBuffer;
+      JsonObject resp_obj = respBuffer.to<JsonObject>();
+
+      resp_obj["secretKey"] = secretKey;
+      resp_obj["durationMs"] = durationMs;
+
+      if (measureJson(respBuffer) > PayloadSize - 1) {
+        Logger::log("too small buffer for JSON data");
+        return;
+      }
+
+      char responsePayload = char[measureJson(respBuffer)];
+      serializeJson(resp_obj, responsePayload);
+
+      m_client.publish("v1/devices/me/claim", responsePayload);
+  }
+
+  //----------------------------------------------------------------------------
   // Telemetry API
 
   // Sends integer telemetry data to the ThingsBoard, returns true on success.

--- a/src/ThingsBoard.h
+++ b/src/ThingsBoard.h
@@ -234,7 +234,7 @@ public:
       char responsePayload[measureJson(respBuffer)];
       serializeJson(resp_obj, responsePayload);
 
-      m_client.publish("v1/devices/me/claim", responsePayload);
+      return m_client.publish("v1/devices/me/claim", responsePayload);
   }
 
   //----------------------------------------------------------------------------

--- a/src/ThingsBoard.h
+++ b/src/ThingsBoard.h
@@ -558,14 +558,14 @@ private:
 
       const JsonObject &data = jsonBuffer.template as<JsonObject>();
 
-      if (!data["provisionDeviceStatus"] == "SUCCESS") {
+      if (data["provisionDeviceStatus"] != "SUCCESS") {
         Logger::log("Provision response contains error: ");
         Logger::log(data["provisionDeviceStatus"]);
         return;
       }
 
       if (data["credentialsType"] == "X509_CERTIFICATE") {
-        Logger::log("Provision response contains X509_CERTIFICATE credentials, it is not supported yet.")
+        Logger::log("Provision response contains X509_CERTIFICATE credentials, it is not supported yet.");
         return;
       }
 

--- a/src/ThingsBoard.h
+++ b/src/ThingsBoard.h
@@ -89,7 +89,7 @@ using Attribute = Telemetry;
 using RPC_Response = Telemetry;
 // JSON object is used to communicate RPC parameters to the client
 using RPC_Data = JsonVariant;
-using Shared_Attribute_Data = JsonVariant;
+using Shared_Attribute_Data = JsonObject;
 using Provision_Data = JsonObject;
 
 // RPC callback wrapper
@@ -220,19 +220,15 @@ public:
   // Claiming API
 
   bool sendClaimingRequest(const char *secretKey, unsigned int durationMs) {
-      StaticJsonDocument<JSON_OBJECT_SIZE(1)> respBuffer;
-      JsonObject resp_obj = respBuffer.to<JsonObject>();
+      StaticJsonDocument<JSON_OBJECT_SIZE(1)> requestBuffer;
+      JsonObject resp_obj = requestBuffer.to<JsonObject>();
 
       resp_obj["secretKey"] = secretKey;
       resp_obj["durationMs"] = durationMs;
 
-      if (measureJson(respBuffer) > PayloadSize - 1) {
-        Logger::log("too small buffer for JSON data");
-        return;
-      }
-
-      char responsePayload[measureJson(respBuffer)];
-      serializeJson(resp_obj, responsePayload);
+      uint8_t objectSize = measureJson(requestBuffer) + 1;
+      char responsePayload[objectSize];
+      serializeJson(resp_obj, responsePayload, objectSize);
 
       return m_client.publish("v1/devices/me/claim", responsePayload);
   }

--- a/test.sh
+++ b/test.sh
@@ -12,14 +12,17 @@ EXAMPLES_ARDUINO_UNO=(
 
 EXAMPLES_ESP8266=(
     "examples/0003-esp8266_send_data"
+    "examples/0006-esp8266_process_shared_attribute_update"
+    "examples/0007-esp8266_claim_device"
+    "examples/0008-esp8266_provision_device"
 )
 
 EXAMPLES=( "${EXAMPLES_ESP8266[@]}" "${EXAMPLES_ARDUINO_UNO[@]}")
 
 # Test if arduino command line interface is downloaded locally
-if [ -f "$(pwd)/arduino-cli-0.3.2-alpha.preview-linux64" ]
+if [ -f "$(pwd)/arduino-cli" ]
 then
-    ARDUINO_CLI="$(pwd)/arduino-cli-0.3.2-alpha.preview-linux64"
+    ARDUINO_CLI="$(pwd)/arduino-cli"
     echo "Found arduino CLI in $ARDUINO_CLI"
 else
     ARDUINO_CLI="arduino-cli"
@@ -33,6 +36,7 @@ do_test() {
 
     for path in "${EXAMPLES_ESP8266[@]}"
     do
+        echo "Processing ESP8266 example with path: ${path}"
         "${ARDUINO_CLI}" compile -b esp8266:esp8266:generic "${path}"
     done
 }


### PR DESCRIPTION
1. Added method for using [shared attributes updates device API](https://thingsboard.io/docs/reference/mqtt-api/#subscribe-to-attribute-updates-from-the-server) and example for usage of this method.
2. Added method for using [claiming device API](https://thingsboard.io/docs/reference/mqtt-api/#claiming-devices) and example for usage of this method and claiming device for customer.
3. Added method for using [provisioning device API](https://thingsboard.io/docs/reference/mqtt-api/#device-provisioning) and example for usage of this method and getting credentials from ThingsBoard instance.